### PR TITLE
Update Travis distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
 language: c
 
-dist: xenial
+dist: bionic
 
 addons:
     apt:
-        sources:
-            - sourceline: 'ppa:jonathonf/meson'
-            - sourceline: 'ppa:jonathonf/gtk3.22'
-            - sourceline: 'ppa:vala-team/ppa'
         packages:
             - valac
             - libgee-0.8-dev


### PR DESCRIPTION
Looks like jonathonf/gtk3.22 PPA has been dropped

I'd propose to update from Xenial to Bionic which doesn't require additional repositories to be added.