### PR TITLE
Fix mute/unmute notification appears even if notifications are disabled

### DIFF
--- a/src/mictray.vala
+++ b/src/mictray.vala
@@ -30,7 +30,7 @@ class MicTrayApp : Gtk.Application
 		{
 			status_icon.update();
 
-			if (config.show_notifications && pulse.old_volume != pulse.volume || pulse.old_muted != pulse.muted)
+			if (config.show_notifications && (pulse.old_volume != pulse.volume || pulse.old_muted != pulse.muted))
 			{
 				try
 				{


### PR DESCRIPTION
Missing parentheses cause mute/unmute notification to be shown